### PR TITLE
bump version to 2.2.2 and track the latest

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,18 +1,18 @@
 pkgbase = picgo-appimage
 	pkgdesc = A simple & beautiful tool for pictures uploading built by electron-vue
-	pkgver = 2.0.2
+	pkgver = 2.2.2
 	pkgrel = 1
 	url = https://molunerfinn.com/PicGo/
 	arch = x86_64
 	license = MIT
-	noextract = picgo-2.0.2-x86_64.AppImage
+	noextract = PicGo-2.2.2.AppImage
 	options = !strip
-	source = https://github.com/Molunerfinn/PicGo/releases/download/v2.0.2/picgo-2.0.2-x86_64.AppImage
+	source = https://github.com/Molunerfinn/PicGo/releases/download/v2.2.2/PicGo-2.2.2.AppImage
 	source = picgo.png
 	source = picgo.desktop
-	sha256sums = ddc9301e92e0c72d5ea9af455904a09f87181362443ec064202e35aadf959927
-	sha256sums = SKIP
-	sha256sums = SKIP
+	sha512sums = e1d6bcc898ae3b42354c3c14c8146ef9d2f226a997bcde751b61b1495b0920c9534c76f49fd6e3d65e40280e086d033033c239a916b7cba1f5fb6ef037690f05
+	sha512sums = SKIP
+	sha512sums = SKIP
 
 pkgname = picgo-appimage
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,27 +1,33 @@
 # Maintainer: Baron Hou <houbaron@gmail.com>
-pkgname=picgo-appimage
-pkgver=2.0.2
-pkgrel=1
+latest_url=$(curl https://github.com/Molunerfinn/PicGo/releases/latest | cut -d '"' -f2)
 
+pkgname=picgo-appimage
+pkgver=$(echo $latest_url| cut -d 'v' -f2)
+
+metadata=$(curl -L "https://github.com/Molunerfinn/PicGo/releases/download/v${pkgver}/latest-linux.yml")
+# sha512=$(echo $metadata | grep '^sha512' |cut -d ' ' -f2)
+sha512='e1d6bcc898ae3b42354c3c14c8146ef9d2f226a997bcde751b61b1495b0920c9534c76f49fd6e3d65e40280e086d033033c239a916b7cba1f5fb6ef037690f05'
+
+pkgrel=1
 pkgdesc="A simple & beautiful tool for pictures uploading built by electron-vue"
 arch=('x86_64')
 url="https://molunerfinn.com/PicGo/"
 license=('MIT')
-noextract=("picgo-${pkgver}-${arch}.AppImage")
+noextract=("PicGo-${pkgver}.AppImage")
 options=("!strip")
 source=(
-    "https://github.com/Molunerfinn/PicGo/releases/download/v${pkgver}/picgo-${pkgver}-${arch}.AppImage"
+    "https://github.com/Molunerfinn/PicGo/releases/download/v${pkgver}/PicGo-${pkgver}.AppImage"
     "picgo.png"
     "picgo.desktop"
 )
-sha256sums=(
-    'ddc9301e92e0c72d5ea9af455904a09f87181362443ec064202e35aadf959927'
+sha512sums=(
+    "${sha512}"
     'SKIP'
     'SKIP'
 )
 
 package() {
-    install -Dm755 "picgo-${pkgver}-${arch}.AppImage" "${pkgdir}/opt/appimages/picgo.AppImage"
+    install -Dm755 "PicGo-${pkgver}.AppImage" "${pkgdir}/opt/appimages/picgo.AppImage"
     install -Dm644 "picgo.desktop"                    "${pkgdir}/usr/share/applications/picgo.desktop"
     install -Dm644 "picgo.png"                        "${pkgdir}/usr/share/icons/hicolor/128x128/apps/picgo.png"
 }

--- a/picgo.desktop
+++ b/picgo.desktop
@@ -5,7 +5,7 @@ Exec=env DESKTOPINTEGRATION=no "/opt/appimages/picgo.AppImage" %U
 Terminal=false
 Type=Application
 Icon=picgo
-X-AppImage-Version=2.0.2
+X-AppImage-Version=2.2.2
 X-AppImage-BuildId=1d6b527a-0ab1-42f8-8f83-95c539186de6
 Categories=Utility;
 Name[zh_CN.utf8]=picgo.desktop


### PR DESCRIPTION
现在由于上游仓库的sha512似乎有误,不能从latest-linux.yml 获取sha512, 